### PR TITLE
[Add] 바코드 API 마무리, 현금 결제 정보 전송

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ function App() {
       <Toaster toastOptions={{ className: 'common-toast' }} />
       <Header />
       <Routes>
-        {/* <Route path='/' element={<AttendaceCheck />} /> */}
+        <Route path='/check' element={<AttendaceCheck />} />
         <Route path='/' element={<Home />} />
         <Route path='/payment' element={<Payment />} />
         <Route path='/paymentlist' element={<Paymentlist />} />

--- a/src/assets/datas/paymentllistDatas.json
+++ b/src/assets/datas/paymentllistDatas.json
@@ -1,9 +1,19 @@
 {
-    "productSeq" : 1,
-    "productName" : "아이셔",
-    "price" : 1000,
-    "priceDiscount": 900,
-    "expirationDate": "2023-11-02 18:00:00",
-    "discountRate": 10,
-    "promotionInfo": 2
+    "productSeq": 2,
+    "convSeq": 1,
+    "categoryId": 1,
+    "productName": "농심)튀김우동큰사발",
+    "productRomanName": "Nongsim)Twigimudongkeunsabal",
+    "productTranslationName": null,
+    "price": 1400,
+    "priceDiscount": 1400,
+    "stockQuantity": 7,
+    "expirationDate": "2023-10-05 18:00:00",
+    "discountRate": 0.0,
+    "promotionInfo": 3,
+    "barcode": "8801043016070",
+    "imgUrl": "https://www.emart24.co.kr/image/NDA5ODE=",
+    "totalStock": 0,
+    "amount": 0,
+    "callDate": null
 }

--- a/src/components/convenience/Login.jsx
+++ b/src/components/convenience/Login.jsx
@@ -29,7 +29,7 @@ function Login(){
 
     const onSubmit = (e) => {
         e.preventDefault();
-        axios.post("http://10.10.10.205:3000/NoSecurityZoneController/login", {
+        axios.post("http://10.10.10.108:3000/NoSecurityZoneController/login", {
             "userId": id,
             "pwd": pw,
         },)

--- a/src/components/employees/AddEmployeeModal.jsx
+++ b/src/components/employees/AddEmployeeModal.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import axios from 'axios';
 
 function AddEmployeeModal({onAdd}) {
-  // 각 입력 필드에 대한 상태를 설정합니다.
   const [empName, setEmpName] = useState('');
   const [convSeq, setConvSeq] = useState(0);
   const [birthDate, setBirthDate] = useState('');
@@ -11,9 +10,9 @@ function AddEmployeeModal({onAdd}) {
   const [hireDate, setHireDate] = useState('');
   const [salary, setSalary] = useState(0);
 
-  // 제출 버튼을 누를 때 실행될 함수입니다.
-  const handleSubmit = () => {
+  const accesstoken = localStorage.getItem("accesstoken");
 
+  const handleSubmit = () => {
     const formatDate = (dateString) => {
       if (dateString.length === 8) {
         return `${dateString.substring(0, 4)}-${dateString.substring(4, 6)}-${dateString.substring(6, 8)}`;
@@ -21,7 +20,6 @@ function AddEmployeeModal({onAdd}) {
       return dateString;
     };
 
-    // 입력한 정보를 JSON 형식으로 만듭니다.
     const employeeData = {
      empName,
       convSeq,
@@ -32,15 +30,14 @@ function AddEmployeeModal({onAdd}) {
       salary
     };
 
-    // axios를 사용하여 서버에 데이터를 전송합니다.
-    axios.post('http://10.10.10.196:3000/addemployee', employeeData)
+    axios.post('http://10.10.10.108:3000/addemployee', employeeData, {
+      headers: { accessToken: `Bearer ${accesstoken}`,}
+    })
       .then(response => {
-        // 성공적으로 데이터를 보냈을 경우 실행될 코드
         console.log('데이터 성공적으로 전송', response);
         onAdd();
       })
       .catch(error => {
-        // 데이터 전송에 실패했을 경우 실행될 코드
         console.log('데이터 전송 실패', error);
 
       });

--- a/src/components/inventory/InvenModal.jsx
+++ b/src/components/inventory/InvenModal.jsx
@@ -42,7 +42,7 @@ function InvenModal (props) {
         "memo": memo
       };
     
-    axios.post('http://10.10.10.152:3000/addsettlement', data)
+    axios.post('http://10.10.10.108:3000/addsettlement', data)
     .then((res) => {
       console.log(res.data);
       console.log('보내기 성공');

--- a/src/components/payment/Cashpay.jsx
+++ b/src/components/payment/Cashpay.jsx
@@ -8,7 +8,7 @@ import { toast } from "react-hot-toast";
 
 
 
-function Cashpay({ openModal, closeModal, totalAmount, setTotalAmount }) {
+function Cashpay({ openModal, closeModal, totalAmount }) {
   const [totalAmountState, setTotalAmountState] = useState(5900); 
   const [inputValue, setInputValue] = useState("");
   const [changeAmount, setChangeAmount] = useState(0);
@@ -88,12 +88,12 @@ function Cashpay({ openModal, closeModal, totalAmount, setTotalAmount }) {
 
   const handlePayment = async () => {
     try {
-        const response = await axios.post("http://10.10.10.205:3000/addpayment", paymentData);
+        const response = await axios.post("http://10.10.10.65:3000/addpayment", paymentData);
         console.log("결제 정보 전송 완료", response.data);
         
         if(response.data === "YES") {
             setPaymentSuccess(true);
-            const itemResponse = await axios.post('http://10.10.10.205:3000/addItems', items);
+            const itemResponse = await axios.post('http://10.10.10.65:3000/addItems', items);
             console.log("결제 상품 목록 전송 완료", itemResponse.data);
 
             closeModal();

--- a/src/components/payment/CashpayReceipt.jsx
+++ b/src/components/payment/CashpayReceipt.jsx
@@ -1,7 +1,7 @@
 import CheckmarkComponent from "../CheckMark";
 import { addComma } from "store/utils/function";
 
-function CashpayReceipt({ closeModal , inputValue , changeAmount , totalAmount}){
+function CashpayReceipt({ closeModal, inputValue, changeAmount, totalAmount}){
    
 
     return(

--- a/src/pages/Employees.jsx
+++ b/src/pages/Employees.jsx
@@ -12,6 +12,7 @@ function Employees() {
     const [employeeType, setEmployeeType] = useState(null);
     const [employeeList, setEmployeeList] = useState([]);
     const [totalCnt, setTotalCnt] = useState(0);
+    const accesstoken = localStorage.getItem("accesstoken");
 
     //모달
     const openModal = (type) => {
@@ -23,10 +24,12 @@ function Employees() {
      };
  
      const fetchEmployees = () => {
-      axios.get('http://10.10.10.196:3000/findallemployee', {params: {convSeq :1}})
+      axios.get('http://10.10.10.108:3000/findallemployee', {params: {convSeq :31}, headers:{ accessToken: `Bearer ${accesstoken}`}})
         .then((res) => {
             setEmployeeList(res.data);
             setTotalCnt(res.data.cnt);
+            console.log('직원 리스트 불러오기 성공');
+            console.log(res.data);
         })
         .catch((err) => {
             console.log(err);

--- a/src/pages/Payment.jsx
+++ b/src/pages/Payment.jsx
@@ -1,23 +1,67 @@
-import React, { useState } from 'react';
-
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import Modal from '../components/Modal';
 import Cashpay from '../components/payment/Cashpay'
 import Etcpay from '../components/payment/Etcpay'
 import Discount from '../components/payment/Discount'
 import Point from '../components/payment/Point'
-import Division from '../components/payment/Division'
 import CashpayReceipt from '../components/payment/CashpayReceipt';
 import { handlePayment } from 'store/utils/cardpay.js';
+import { addComma } from 'store/utils/function.js';
+import { toast } from 'react-hot-toast';
 
 
 
 function Payment() {
     const [modalIsOpen, setModalIsOpen] = useState(false);
     const [paymentType, setPaymentType] = useState(null);
-    const [inputValue, setInputValue] = useState(""); 
-    const [changeAmount, setChangeAmount] = useState(0); 
-    const [totalAmount, setTotalAmount] = useState(5900); 
     const [paymentResponse, setPaymentResponse] = useState(null);
+    const [barcodeInput, setBarcodeInput] = useState("");
+    const [products, setProducts] = useState([]);
+
+    
+
+    const handleBarcode = () => {
+        const barcodeInput = document.querySelector('.input-barcode').value;
+        if(!barcodeInput) {
+            toast.error("바코드 인식 에러");
+            return;
+        }
+    
+        axios.get('http://10.10.10.140:3000/findProductBarcode', {params: {Barcode: barcodeInput, convSeq: 1}})
+        .then((res) => {
+            const productData = res.data;
+            const existingProduct = products.find(p => p.productSeq === productData.productSeq);
+    
+            if (existingProduct) {
+                setProducts(prevProducts => {
+                    return prevProducts.map(p => {
+                        if (p.productSeq === productData.productSeq) {
+                            return { ...p, amount: p.amount + 1 };
+                        }
+                        return p;
+                    });
+                });
+            } else {
+                productData.amount = 1;
+                setProducts(prevProducts => [...prevProducts, productData]);
+            }
+    
+        })
+        .catch((err) => {
+            console.log(err);
+            toast.error('상품을 찾을 수 없습니다.');
+        })
+        setBarcodeInput("");
+    }
+
+    const getTotalAmount = () => {
+        return products.reduce((total, product) => {
+            return total + (product.priceDiscount) * product.amount;
+        }, 0);
+    };
+    
+
 
     const startPayment = async () => {
         await handlePayment(setPaymentResponse);
@@ -47,59 +91,47 @@ function Payment() {
             },
         };
     };
-  
     
 
+    /* 사용자가 어느부분을 클릭해도 INPUT에 포커스 되도록 하는 함수 구현 해야 함 */
+   
 
     return (
         <div className="payment-container">
             <div className='payment-header'>
                 <div className='page-title'>결제</div>
+                <input className='input-barcode' placeholder='여기에 바코드를 입력' value={barcodeInput} onChange={(e) => setBarcodeInput(e.target.value)} 
+                    autoFocus onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            handleBarcode();
+                        } }}/>
+
+
             </div>
             
             <div className='payment-body'>
                 <div className='payment-list'>
                     <div className='payment-list-list'>
-                        <div className='payment-list-row'>
-                            <div className='payment-list-row-info'>
-                                <div className='payment-list-name'>아메리카노</div>
-                                <div className='payment-list-amount'>x 1</div>
-                                <div className='payment-list-price'>2,500 원</div>
+                       
+                        {products.map(product => (
+                            <div className='payment-list-row' key={product.productSeq}>
+                                <div className='payment-list-row-info'>
+                                    <div className='payment-list-name'>{product.productName}</div>
+                                    {/*  <div className='payment-list-amount'>x {product.amount}</div>  amount 사용하면 안됨 수정*/}
+                                    <div className='payment-list-price'>{addComma(product.price * product.amount)} 원</div>
+                                </div>
+                                <div className='payment-list-discount-info'>
+                                    <div className='payment-list-discount'>할인</div>
+                                    <div className='payment-list-discount2'>-{addComma((product.price - product.priceDiscount) * product.amount)} 원</div>
+                                </div>
                             </div>
-                            <div className='payment-list-discount-info'>
-                                <div className='payment-list-discount'>할인</div>
-                                <div className='payment-list-discount2'>-500 원</div>
-                            </div>
-                        </div>
-
-                        <div className='payment-list-row'>
-                            <div className='payment-list-row-info'>
-                                <div className='payment-list-name'>바닐라 라떼</div>
-                                <div className='payment-list-amount'>x 3</div>
-                                <div className='payment-list-price'>10,500 원</div>
-                            </div>
-                            <div className='payment-list-discount-info'>
-                                <div className='payment-list-discount'>정재원 할인</div>
-                                <div className='payment-list-discount2'>-500 원</div>
-                            </div>
-                        </div>
-
-                        <div className='payment-list-row'>
-                            <div className='payment-list-row-info'>
-                                <div className='payment-list-name'>프로틴 쉐이크</div>
-                                <div className='payment-list-amount'>x 2</div>
-                                <div className='payment-list-price'>8,000 원</div>
-                            </div>
-                            <div className='payment-list-discount-info'>
-                                <div className='payment-list-discount'>할인</div>
-                                <div className='payment-list-discount2'>-500 원</div>
-                            </div>
-                        </div>
+                        ))}
                     </div>
+
                     
                     <div className='payment-list-result'>
                         <div className='payment-list-total'>총액</div>
-                        <div className='payment-list-total2'>2000 원</div>
+                        <div className='payment-list-total2'>{addComma(getTotalAmount())} 원</div>
                     </div> 
                 </div>
 
@@ -107,7 +139,7 @@ function Payment() {
                     <div className='container'>
                         <div className='payment-total'>결제 금액</div>
                         <div className='payment-total-container'>
-                            <div className='payment-total-price'>2,000 원</div>
+                            <div className='payment-total-price'>{addComma(getTotalAmount())} 원</div>
                             <button className='payment-division-button' onClick={() => openModal('cash')}>현금 결제</button>
                         </div>
                         <div className='payment-method-container2'>
@@ -118,17 +150,17 @@ function Payment() {
                             <div className='payment-method-bottom'>
                                 <button className='payment-method-cardpay' onClick={startPayment}>토스페이 결제</button>
                                 <button className='payment-method-cashpay' onClick={() => openModal('cash')}></button>
-                                <button className='payment-method-etcpay' onClick={() => openModal('etc')}>기타 결제</button>
+                                <button className='payment-method-etcpay'>테스트</button>
                             </div>
                         </div>
-                </div>
+                    </div>
                 </div>
             </div>
             
 
             <Modal isOpen={modalIsOpen} onClose={closeModal} style={getModalStyle()}>
-                {paymentType === 'cash' && <Cashpay openModal={openModal} closeModal={closeModal} setInputValue={setInputValue} setChangeAmount={setChangeAmount} totalAmount={totalAmount} setTotalAmount={setTotalAmount}/>}
-                {paymentType === 'receipt' && <CashpayReceipt closeModal={closeModal} inputValue={inputValue} changeAmount={changeAmount} totalAmount={totalAmount}/>} 
+                {paymentType === 'cash' && <Cashpay openModal={openModal} closeModal={closeModal} totalAmount={getTotalAmount()}/>}
+                {paymentType === 'receipt' && <CashpayReceipt closeModal={closeModal}/>} 
                 {paymentType === 'etc' && <Etcpay />}
                 {paymentType === 'discount' && <Discount />}
                 {paymentType === 'point' && <Point />}

--- a/src/styles/page/payment/payment.scss
+++ b/src/styles/page/payment/payment.scss
@@ -24,11 +24,11 @@
                 height: 33rem;
                 .payment-list-row{
                     border-bottom: 1px solid $color-border;
-                    padding-bottom: 10px;
+                    padding-bottom: 1rem;
                     .payment-list-row-info{
                         display: grid;
                         grid-template-columns: 2fr 1fr 1fr;
-                        padding: 2rem 2rem 0 2rem;
+                        padding: 2rem 2rem 0rem 2rem;
                         .payment-list-name{
                             font-weight: 500;
                         }
@@ -40,7 +40,7 @@
                         }
                     }
                     .payment-list-discount-info{
-                        padding: 10px 5rem 0 3rem;
+                        padding: 10px 3rem 0 3rem;
                         display: flex;
                         justify-content: space-between;
                         .payment-list-discount{

--- a/src/styles/page/payment/payment.scss
+++ b/src/styles/page/payment/payment.scss
@@ -7,6 +7,10 @@
         padding-left: 2rem;
         display: flex;
         align-items: center;
+
+        .input-barcode{
+            opacity: 0;
+        }
     }
     
     .payment-body{


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 작성
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 작성 -->
- #110 


## ✨ 구현 내용
<!-- 구현 내용에 대한 설명을 작성 -->
- 바코드 스캔으로 불러온 상품의 정보와, 해당 상품들의 현금 결제 정보를 서버로 넘겨주었습니다.
- 사용자가 화면상의 어느 공간을 터치해도 바코드를 입력받는 input태그에 커서가 고정되도록 하였습니다.
- discountRate가 0일 경우 할인 정보가 없기 때문에, 할인 정보를 분기처리하였습니다.
- 현금 결제 금액이 0원일 때, 결제할 상품이 없다는 알림을 사용자에게 알려주었습니다.

## 📚 참고 사항
<!-- 참고할 사항이 있다면 작성, 안 쓰면 삭제 -->
- 해당 내용은 현금 결제에 한한 내용이며 토스페이 결제를 다음으로 진행할 계획입니다.
