### PR TITLE
[Add] 일별 매출 보고서 API

### DIFF
--- a/src/components/analysis/DailySales.jsx
+++ b/src/components/analysis/DailySales.jsx
@@ -15,24 +15,33 @@ function DailySales(){
         setSelectedDate(date);
     };
 
-    const onClick = async () => {   
+    const fetchData = async (selectedDate) => {   
         try {
-            const res = await axios.get("http://54.180.60.149:3000//selectSales", {
-                params: {
-                    date: "2023년07월20일", // 임시로 받는 데이터
-                    choice: 0 // 일별 매출 0번
-                }
-            } ,{
+
+            const year = selectedDate.getFullYear();
+            const month = String(selectedDate.getMonth() + 1).padStart(2, '0');
+            const day = String(selectedDate.getDate()).padStart(2, '0');
+            const dailySalesdDate = `${year}년${month}월${day}일`;
+            console.log("dailySalesdDate >>> ", dailySalesdDate)
+            const res = await axios.get(`http://54.180.60.149:3000/selectSales?date=${dailySalesdDate}&choice=0`,
+            {
                 headers: {
                     accessToken: `Bearer ${accesstoken}`,
                 },
             })
+            console.log("DailySales res >>> ", res);
             const resData = res.data;
             setSalesData(resData.sales);
             setExpenseData(resData.expenses);
             setProfitData(resData.profit);
         } catch (error) {
             console.error('try-catch 데이터 가져오기 오류:', error);
+        }
+    }
+    const onClick = () => {
+        if (selectedDate) {
+            // API 호출
+            fetchData(selectedDate);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 작성
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 작성 -->
- #158 


## ✨ 구현 내용
<!-- 구현 내용에 대한 설명을 작성 -->
- API param 임시로 설정한 날짜를 캘린더에서 선택한 날짜가 "yyyy년MM월dd일" 전달 되도록 수정
- API 테스트 결과 성공

## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요하다면 첨부, 안 쓰면 삭제 -->
![image](https://github.com/KDT-POSSG/POSSG_FE/assets/117338227/ed88214b-7856-4238-8d9c-4be637b59312)



## 📚 참고 사항
<!-- 참고할 사항이 있다면 작성, 안 쓰면 삭제 -->
- 백 일별 매출 보고서 데이터가 없어서 정확한 데이터가 넘어오는지 확인 필요함
- 캘린더 디자인 수정
