### PR TITLE
[Add] 매출 페이지 구현

### DIFF
--- a/src/components/analysis/DailySales.jsx
+++ b/src/components/analysis/DailySales.jsx
@@ -1,28 +1,30 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import MyChart from '../../store/utils/MyChart';
 import { baseURL } from 'store/apis/base';
 import { addComma } from 'store/utils/function';
 import Calendar from './Calendar';
+import toast from 'react-hot-toast';
+import MyPieChart from 'store/utils/MyPieChart';
 
 function DailySales(){
     const accesstoken = localStorage.getItem("accesstoken");
 
     const [selectedDate, setSelectedDate] = useState(null);
-    const [salesData, setSalesData] = useState([]); 
+    const [salesData, setSalesData] = useState({}); 
     const [data, setData] = useState(false);
 
     const handleDateChange = (date) => {
         setSelectedDate(date);
     };
 
-    const chartOptions = {
-        scales: {
-            y: {
-                beginAtZero: true,
-                max: 100000, // 임시로 설정
-            },
-        },
+    const getIncreaseRateColor = () => {
+        if (salesData.increaseRate > 0) {
+            return "positive-increase";
+        } else if (salesData.increaseRate === 0) {
+            return "zero-increase";
+        } else {
+            return "negative-increase";
+        }
     };
 
     const fetchData = async (selectedDate) => {   
@@ -38,18 +40,19 @@ function DailySales(){
                     accessToken: `Bearer ${accesstoken}`,
                 },
             })
-            // console.log("DailySales res >>> ", res);
+            console.log("DailySales res >>> ", res);
             const resData = res.data;
             console.log("resData >>> ", resData)
             if(resData){
                 setSalesData(resData);
                 setData(true);
-            }else{
+            }
+            else{
                 setSalesData(0)
                 setData(true);
-            }
-            
+            }     
         } catch (err) {
+            toast.error("해당 날짜에는 조회할 자료가 없습니다");
             console.error('try-catch 오류:', err);
             setData(false);
         }
@@ -80,12 +83,77 @@ function DailySales(){
                 <div className="sales-data-container">
                     <div className="sales-data">
                         <div className="sales-data-title">총 매출</div>
-                        <div className="sales-data-amount">{addComma(salesData)}</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalPrice)}원</div>
+                            {salesData.increaseRate !== undefined && (
+                                <p className={`sales-data-increaseRate ${getIncreaseRateColor()}`}>
+                                    {salesData.increaseRate > 0
+                                    ? `↑${salesData.increaseRate}%`
+                                    : salesData.increaseRate === 0
+                                    ? `${salesData.increaseRate}%`
+                                    : `↓${salesData.increaseRate}%`}
+                                </p>
+                            )}
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">결제 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">총 비용</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalLoss)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">순 이익</div>
+                        <div className="sales-data-amount">{addComma(salesData.profit)}원</div>
                     </div>
                 </div>
-                <div className="sales-chart"> 
-                    <MyChart data={[salesData]} labels={["매출"]} chartOptions={chartOptions} />
-                </div>
+
+                {salesData.totalPrice === 0 && salesData.totalLoss === 0 && salesData.profit === 0 ? (
+                    <div className="sales-no-datas">
+                        <p className="select-no-text">저장된 데이터가 없습니다</p>&nbsp;&nbsp;&nbsp;
+                        <span class="material-symbols-rounded chart-icon">bar_chart_4_bars</span>       
+                    </div>
+                ) : (
+                    <div className="sales-chart-datas"> 
+                        <div className="sales-chart">
+                            <MyPieChart
+                                data={[salesData.totalPrice, salesData.totalLoss, salesData.profit]}
+                                labels={["총 매출", "총 비용", "순 이익"]}
+                                chartOptions={{}}
+                            />
+                        </div>
+                        <div className="sales-datas-container">
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 매출</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalPrice)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 비용</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalLoss)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">순 이익</div>
+                                <div className="sales-datas-amount">{addComma(salesData.profit)}원</div>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
             ) : (
                 <div className="select-date-message">

--- a/src/components/analysis/MonthlySales.jsx
+++ b/src/components/analysis/MonthlySales.jsx
@@ -1,28 +1,30 @@
 import axios from 'axios';
 import React, { useState } from 'react';
-import MyChart from '../../store/utils/MyChart';
 import { baseURL } from 'store/apis/base';
 import { addComma } from 'store/utils/function';
 import Calendar from './Calendar';
+import toast from 'react-hot-toast';
+import MyPieChart from 'store/utils/MyPieChart';
 
 function MonthlySales(){
     const accesstoken = localStorage.getItem("accesstoken");
 
     const [selectedDate, setSelectedDate] = useState(null);
-    const [salesData, setSalesData] = useState([]); 
+    const [salesData, setSalesData] = useState({});
     const [data, setData] = useState(false);
 
     const handleDateChange = (date) => {
     setSelectedDate(date);
     };
 
-    const chartOptions = {
-        scales: {
-            y: {
-                beginAtZero: true,
-                max: 5000000, // 임시로 설정
-            },
-        },
+    const getIncreaseRateColor = () => {
+        if (salesData.increaseRate > 0) {
+            return "positive-increase";
+        } else if (salesData.increaseRate === 0) {
+            return "zero-increase";
+        } else {
+            return "negative-increase";
+        }
     };
 
     const fetchData = async (selectedDate) => {   
@@ -38,7 +40,7 @@ function MonthlySales(){
                     accessToken: `Bearer ${accesstoken}`,
                 },
             })
-            console.log("monthSalesdDate res >>> ", res);
+            // console.log("monthSalesdDate res >>> ", res);
             const resData = res.data;
             console.log("resData >>> ", resData)
             if(resData){
@@ -50,6 +52,7 @@ function MonthlySales(){
             }
             
         } catch (err) {
+            toast.error("해당 날짜에는 조회할 자료가 없습니다");
             console.error('try-catch 오류:', err);
             setData(false);
         }
@@ -70,21 +73,85 @@ function MonthlySales(){
                         onChange={handleDateChange}
                         type="month" 
                     />
-                    <div className="material-symbols-rounded">calendar_month</div>
+                    <div className="material-symbols-rounded calendar-icon">calendar_month</div>
                     <button className="calendar-button" type="button" onClick={onClick}>조회</button>
                 </div>
             </div>
             {data ? (
             <div className="sales-content">
                 <div className="sales-data-container">
-                    <div className="sales-data">
+                <div className="sales-data">
                         <div className="sales-data-title">총 매출</div>
-                        <div className="sales-data-amount">{addComma(salesData)}</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalPrice)}원</div>
+                            {salesData.increaseRate !== undefined && (
+                                <p className={`sales-data-increaseRate ${getIncreaseRateColor()}`}>
+                                    {salesData.increaseRate > 0
+                                    ? `↑${salesData.increaseRate}%`
+                                    : salesData.increaseRate === 0
+                                    ? `${salesData.increaseRate}%`
+                                    : `↓${salesData.increaseRate}%`}
+                                </p>
+                            )}
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">결제 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">총 비용</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalLoss)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">순 이익</div>
+                        <div className="sales-data-amount">{addComma(salesData.profit)}원</div>
                     </div>
                 </div>
-                <div className="sales-chart"> 
-                    <MyChart data={[salesData]} labels={["매출"]} chartOptions={chartOptions}  />
-                </div>
+                {salesData.totalPrice === 0 && salesData.totalLoss === 0 && salesData.profit === 0 ? (
+                    <div className="sales-no-datas">
+                        <p className="select-no-text">저장된 데이터가 없습니다</p>&nbsp;&nbsp;&nbsp;
+                        <span class="material-symbols-rounded chart-icon">bar_chart_4_bars</span>       
+                    </div>
+                ) : (
+                    <div className="sales-chart-datas"> 
+                        <div className="sales-chart">
+                            <MyPieChart
+                                data={[salesData.totalPrice, salesData.totalLoss, salesData.profit]}
+                                labels={["총 매출", "총 비용", "순 이익"]}
+                                chartOptions={{}}
+                            />
+                        </div>
+                        <div className="sales-datas-container">
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 매출</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalPrice)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 비용</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalLoss)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">순 이익</div>
+                                <div className="sales-datas-amount">{addComma(salesData.profit)}원</div>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
             ) : (
                 <div className="select-date-message">

--- a/src/components/analysis/YearSales.jsx
+++ b/src/components/analysis/YearSales.jsx
@@ -4,6 +4,8 @@ import MyChart from '../../store/utils/MyChart';
 import { baseURL } from 'store/apis/base';
 import { addComma } from 'store/utils/function';
 import Calendar from './Calendar';
+import MyPieChart from 'store/utils/MyPieChart';
+import toast from 'react-hot-toast';
 
 function YearSales(){
     const accesstoken = localStorage.getItem("accesstoken");
@@ -16,13 +18,14 @@ function YearSales(){
         setSelectedDate(date);
     };
 
-    const chartOptions = {
-        scales: {
-            y: {
-                beginAtZero: true,
-                max: 10000000, // 임시로 설정
-            },
-        },
+    const getIncreaseRateColor = () => {
+        if (salesData.increaseRate > 0) {
+            return "positive-increase";
+        } else if (salesData.increaseRate === 0) {
+            return "zero-increase";
+        } else {
+            return "negative-increase";
+        }
     };
     
     const fetchData = async (selectedDate) => {   
@@ -48,6 +51,7 @@ function YearSales(){
                 setData(true);
             }
         } catch (err) {
+            toast.error("해당 날짜에는 조회할 자료가 없습니다");
             console.error('try-catch 오류:', err);
             setData(false);
         }
@@ -75,14 +79,78 @@ function YearSales(){
             {data ? (
             <div className="sales-content">
                 <div className="sales-data-container">
-                    <div className="sales-data">
+                <div className="sales-data">
                         <div className="sales-data-title">총 매출</div>
-                        <div className="sales-data-amount">{addComma(salesData)}</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalPrice)}원</div>
+                            {salesData.increaseRate !== undefined && (
+                                <p className={`sales-data-increaseRate ${getIncreaseRateColor()}`}>
+                                    {salesData.increaseRate > 0
+                                    ? `↑${salesData.increaseRate}%`
+                                    : salesData.increaseRate === 0
+                                    ? `${salesData.increaseRate}%`
+                                    : `↓${salesData.increaseRate}%`}
+                                </p>
+                            )}
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">결제 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">할인 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.discountCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 금액</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundPrice)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">환불 건수</div>
+                        <div className="sales-data-amount">{addComma(salesData.refundCount)}건</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">총 비용</div>
+                        <div className="sales-data-amount">{addComma(salesData.totalLoss)}원</div>
+                    </div>
+                    <div className="sales-data">
+                        <div className="sales-data-title">순 이익</div>
+                        <div className="sales-data-amount">{addComma(salesData.profit)}원</div>
                     </div>
                 </div>
-                <div className="sales-chart"> 
-                    <MyChart data={salesData} labels={["매출"]} chartOptions={chartOptions} />
-                </div>
+                {salesData.totalPrice === 0 && salesData.totalLoss === 0 && salesData.profit === 0 ? (
+                    <div className="sales-no-datas">
+                        <p className="select-no-text">저장된 데이터가 없습니다</p>&nbsp;&nbsp;&nbsp;
+                        <span class="material-symbols-rounded chart-icon">bar_chart_4_bars</span>       
+                    </div>
+                ) : (
+                    <div className="sales-chart-datas"> 
+                        <div className="sales-chart">
+                            <MyPieChart
+                                data={[salesData.totalPrice, salesData.totalLoss, salesData.profit]}
+                                labels={["총 매출", "총 비용", "순 이익"]}
+                                chartOptions={{}}
+                            />
+                        </div>
+                        <div className="sales-datas-container">
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 매출</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalPrice)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">총 비용</div>
+                                <div className="sales-datas-amount">{addComma(salesData.totalLoss)}원</div>
+                            </div>
+                            <div className="sales-datas">
+                                <div className="sales-datas-title">순 이익</div>
+                                <div className="sales-datas-amount">{addComma(salesData.profit)}원</div>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div> 
             ) : (
                 <div className="select-date-message">

--- a/src/store/utils/MyPieChart.js
+++ b/src/store/utils/MyPieChart.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react";
+import { Chart, registerables } from "chart.js";
+
+const MyPieChart = ({ data, labels, chartOptions }) => {
+    const chartRef = useRef(null);
+    let chartInstance = null;
+
+    useEffect(() => {
+        const ctx = chartRef.current.getContext("2d");
+
+        const createChart = () => {
+        Chart.register(...registerables);
+        chartInstance = new Chart(ctx, {
+            type: "pie",
+            data: {
+            labels: labels,
+            datasets: [
+                {
+                label: "",
+                data: data,
+                backgroundColor: [
+                    "rgba(255, 99, 132, 0.2)",
+                    "rgba(54, 162, 235, 0.2)",
+                    "rgba(255, 206, 86, 0.2)",
+                ],
+                },
+            ],
+            },
+            options: chartOptions,
+        });
+    };
+
+    const destroyChart = () => {
+        if (chartInstance) {
+            chartInstance.destroy();
+            chartInstance = null;
+        }
+    };
+
+    destroyChart();
+    createChart();
+
+    return () => {
+        destroyChart();
+    };
+    }, [data]);
+
+    return <canvas ref={chartRef} />;
+};
+
+export default MyPieChart;

--- a/src/styles/page/analysis/sales.scss
+++ b/src/styles/page/analysis/sales.scss
@@ -1,7 +1,5 @@
 .sales-content-wrap{
     background-color: $color-back;
-    padding: 3vw 10vw;
-    min-height: 100vh;
 
     .sales-nav{
         display: flex;
@@ -10,7 +8,6 @@
         margin-bottom: 1.875rem;
 
         .sales-title {
-            font-size: 2rem;
             text-align: center;
         }
 
@@ -22,6 +19,7 @@
                 padding: 10px 20px;
                 top: 7px;
                 left: 10px;
+                color: $color-main;
             }
             .calendar-button{
                 position: absolute;
@@ -35,17 +33,16 @@
         }
     }
     .sales-content{
-        margin: 50px 0;
+        padding: 20px 0;
 
         .sales-data-container{
             margin: 0 auto;
-            padding: 10px 0;
             background-color: $color-white;
             border-radius: 1rem;
             filter: drop-shadow(2px 2px 2px rgba($color-border, $alpha: 0.5));
             display: grid;
-            grid-template-columns: repeat(1, 1fr);
-            grid-row-gap: 3rem;
+            grid-template-columns: repeat(4, 1fr);
+            grid-row-gap: 2rem;
             grid-column-gap: 2rem;
             
             .sales-data{
@@ -53,27 +50,99 @@
                 display: flex;
                 flex-direction: column;
                 align-items: center;
-                
+                justify-content: center;
+
                 .sales-data-title{
-                    font-weight: bold;
                     margin-bottom: 1.25rem;
+                    padding: 0 50px;
+                    
                 }
 
                 .sales-data-amount{
-                    font-size: 24px;
-                    font-weight: bold;
-                    color: #f95a00;
+                    font-size: 20px;
+                    font-weight: bold; 
+                }
+                .sales-data-increaseRate{
+                    position: absolute;
+                    bottom: 140px;
+                    padding: 5px 10px;
+                    border-radius: 12px;
+                    
+                }
+                .sales-data-increaseRate.positive-increase {
+                    border: 1px solid rgba($color-red, $alpha: 0.5);
+                    color: $color-red;
+                }
+                
+                .sales-data-increaseRate.zero-increase {
+                    border: 1px solid rgba($color-gray, $alpha: 0.5);
+                    color: $color-gray;
+                }
+                
+                .sales-data-increaseRate.negative-increase {
+                    border: 1px solid rgba(rgba(49, 49, 246), $alpha: 0.5);
+                    color: rgba(49, 49, 246);
                 }
             }
         }
 
-        .sales-chart{
+        .sales-no-datas{
             padding: 4rem;
-            // border: 1px solid $color-border;
             background-color: $color-white;
             border-radius: 1rem;
             filter: drop-shadow(2px 2px 2px rgba($color-border, $alpha: 0.5));
             margin: 30px 0px;
+            padding: 30px 30px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            align-content: center;
+
+            p{
+                color: $color-red;
+            }
+
+            .material-symbols-rounded{
+                color: $color-red;
+            }
+            
+        }
+
+        .sales-chart-datas{
+            padding: 4rem;
+            background-color: $color-white;
+            border-radius: 1rem;
+            filter: drop-shadow(2px 2px 2px rgba($color-border, $alpha: 0.5));
+            margin: 30px 0px;
+            padding: 30px 30px;
+            display: flex;
+            justify-content: space-around;
+            align-items: center;
+            align-content: center;
+            
+            .sales-chart{
+            }
+            .sales-datas-container{
+                display: grid;
+                grid-template-columns: repeat(1, 1fr);
+                grid-row-gap: 1rem;
+                grid-column-gap: 4rem;               
+                
+                .sales-datas{
+                    padding: 20px 20px;
+
+                    .sales-datas-title{
+                        margin-bottom: 1.25rem;
+                    }
+
+                    .sales-datas-amount{
+                        font-size: 20px;
+                        font-weight: bold;
+                        color: $color-point; 
+
+                    }
+                }
+            }
         }
     }
 
@@ -90,7 +159,6 @@
 
         .select-date-text {
             margin-top: 1rem;
-            margin-bottom: 2rem;
             line-height: 1.2;
         }
     }

--- a/src/styles/page/analysis/salesReport.scss
+++ b/src/styles/page/analysis/salesReport.scss
@@ -1,11 +1,13 @@
 .salesReport-content-wrap{
     background-color: $color-back;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     padding: 3vw 10vw;
-    min-height: 100vh;
 
     .salesReport-sort-wrap{
-        width: 75%;
-        margin-left: 170px;
+        width: 80vw;
 
         .salesReport-sort {
             border-radius: 1rem;
@@ -14,7 +16,7 @@
             display: grid;
             grid-template-columns: repeat(3, 1fr);
             padding: 1rem 0;
-            margin-bottom: 1.5rem;
+            margin-bottom: 1.875rem;
             justify-content: center;
             align-items: center;
             text-align: center;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000) 작성
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 작성 -->
- #235 


## ✨ 구현 내용
<!-- 구현 내용에 대한 설명을 작성 -->
- UX / UI 수정
- 매출 자료 항목 추가
   - 총 매출, 총 비용, 순 수익 -> 총 매출, 총 비용, 순 이익, 결제 건수, 할인 금액, 할인 건수, 환불 금액, 환불 건수, 상승률
- 상승률 구분
   - 0원 이상 -> 빨강색
   - 0원 이하 -> 파랑색
   - 0원         -> 기본색
- bar 차트 -> pie 차트로 변경
- 총 매출, 총 비용, 순 수익 데이터 0원으로 들어올 때
   - 차트, 데이터 항목, 금액 대신 저장된 데이터가 없다고 띄워줌

## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요하다면 첨부, 안 쓰면 삭제 -->
- 기본 화면
![image](https://github.com/KDT-POSSG/POSSG_FE/assets/117338227/f6efce05-364f-429e-8804-fd903e964f0d)

- 항목 추가,  Pie 차트 변경
![image](https://github.com/KDT-POSSG/POSSG_FE/assets/117338227/d172ca35-59e2-4ebb-860f-644745912ae0)

- 상승률, 하락률에 대한 css 적용
![image](https://github.com/KDT-POSSG/POSSG_FE/assets/117338227/29fd3bd2-464c-43de-a703-7a9b182c2b64)

- 총 매출, 총 비용, 순 수익 데이터 0원으로 들어올 때
![image](https://github.com/KDT-POSSG/POSSG_FE/assets/117338227/6fa255fe-b4ba-44bf-8c7c-a3f2ae8d695b)


